### PR TITLE
Initial CI/CD setup

### DIFF
--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -25,3 +25,25 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
+  publish:
+    name: Publish python distribution to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/stmeasures
+    permissions:
+      id-token: write
+    steps:
+    - name: Download distribution
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -18,6 +18,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+    - name: Create alpha tag 0.0.0a0.devN
+      run: git tag 0.0.0a0.dev$(git rev-parse --short HEAD | cut -c 1-7 | xxd -p | tr -d '\n' | printf "%d" "0x$(cut -c 1-7)")
     - name: Build package
       run: python -m build
     - name: Store the distribution packages

--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -1,0 +1,27 @@
+name: Build and Publish Python Package to TestPyPI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build and store distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install pypa/build
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/

--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -18,6 +18,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+    - name: Create alpha tag 0.0.0a
+      run: git tag 0.0.0a
     - name: Build package
       run: python -m build
     - name: Store the distribution packages

--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -18,8 +18,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
-    - name: Create alpha tag 0.0.0a
-      run: git tag 0.0.0a
     - name: Build package
       run: python -m build
     - name: Store the distribution packages

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# stmeasures
+# Similar Trajectories Measurements
+
+`stmeasures` is a library which main purpose is to provide researches in GIS
+topics a simple and efficient way to measure how likely trajectories can be
+supporting different use cases and scenarios, depending on the context of
+where and/or how the trajectories were collected, used and their purpose.
+
+Below, you can see the overall idea of the library structure.
+
+![image](https://github.com/user-attachments/assets/0242f0c7-1a13-4399-81d1-a6db10aa0c68)
+
+This project is under construction as a research initiative for a final
+bachelor project at IPN university (Mexico City, 2024).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,16 +44,14 @@ classifiers = [
 Repository = "https://github.com/TT2024-B106/stmeasures.git"
 Issues = "https://github.com/TT2024-B106/stmeasures/issues"
 
-[tool.hatch.build]
-artifacts = ["stmeasures/_version.py"]
-
 [tool.hatch.version]
 source = "versioningit"
-
-[tool.versioningit]
 default-version = "0.0.0a"
 
-[tool.versioningit.format]
+[tool.hatch.version.format]
 distance = "{next_version}dev{distance}{vcs}{rev}"
 dirty = "{version}dirty"
 distance-dirty = "{next_version}dev{distance}{vcs}{rev}dirty"
+
+[tool.hatch.build]
+artifacts = ["dist/_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,8 @@ default-version = "0.0.0a"
 distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{version}+dirty"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"
+
+[tool.versioningit.vcs]
+method = "git"
+match = ["v*"]
+default-tag = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Issues = "https://github.com/TT2024-B106/stmeasures/issues"
 
 [tool.hatch.version]
 source = "versioningit"
-default-version = "0.0.0+unknown"
+default-version = "0.0.0a"
 
 [tool.hatch.version.format]
 distance = "{next_version}.dev{distance}+{vcs}{rev}"
@@ -57,7 +57,7 @@ dirty = "{version}+dirty"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"
 
 [tool.versioningit]
-default-version = "0.0.0+unknown"
+default-version = "0.0.0a"
 format = "{base_version}+{distance}.g{rev}"
 
 [tool.versioningit.tag2version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = [
+    "hatchling",
+	"versioningit",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "stmeasures"
+dynamic = ["version"]
+#TODO: Add the dependencies the project will need
+requires-python = ">= 3.8"
+authors = [
+  {name = "Eduardo Mendoza", email = "emendozam1501@alumno.ipn.mx"},
+  {name = "Javier Munguia", email = "fmunguiag1400@alumno.ipn.mx"},
+  {name = "Marco Ortega", email = "mortegaf1500@alumno.ipn.mx"},
+  {name = "Amilcar Meneses"},
+  {name = "Erika Hernandez"},
+]
+maintainers = [
+  {name = "Eduardo Mendoza", email = "emendozam1501@alumno.ipn.mx"},
+  {name = "Javier Munguia", email = "fmunguiag1400@alumno.ipn.mx"},
+  {name = "Marco Ortega", email = "mortegaf1500@alumno.ipn.mx"},
+]
+description = "A library for measuring trajectory similarities."
+readme = "README.md"
+license = {file = "LICENSE"}
+keywords = [
+  "mobile devices", "measurement similarities", "mobility patterns",
+  "trajectory similarities", "geojson"
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Researchers",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: GIS",
+]
+
+#TODO: Add optional dependencies through `project.optional` (if needed)
+
+[project.urls]
+#TODO: Add readthedocs link for `Documentation`
+Repository = "https://github.com/TT2024-B106/stmeasures.git"
+Issues = "https://github.com/TT2024-B106/stmeasures/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,16 +55,3 @@ default-version = "0.0.0a"
 distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{version}+dirty"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"
-
-[tool.versioningit]
-default-version = "0.0.0a"
-format = "{base_version}+{distance}.g{rev}"
-
-[tool.versioningit.tag2version]
-pattern = "(?P<base_version>.*)"
-
-[tool.versioningit.versioning]
-scheme = "guess-next-dev"
-
-[tool.versioningit.commit]
-sha_length = 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ classifiers = [
 Repository = "https://github.com/TT2024-B106/stmeasures.git"
 Issues = "https://github.com/TT2024-B106/stmeasures/issues"
 
+[tool.hatch.build]
+artifacts = ["stmeasures/_version.py"]
+
 [tool.hatch.version]
 source = "versioningit"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Issues = "https://github.com/TT2024-B106/stmeasures/issues"
 source = "versioningit"
 default-version = "0.0.0a"
 
-[tool.hatch.version.format]
-distance = "{next_version}.dev{distance}+{vcs}{rev}"
-dirty = "{version}+dirty"
-distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"
+[tool.versioningit.format]
+distance = "{base_version}dev{distance}{vcs}{rev}"
+dirty = "{base_version}d{build_date:%Y%m%d}"
+distance-dirty = "{base_version}dev{distance}{vcs}{rev}d{build_date:%Y%m%d}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,3 @@ default-version = "0.0.0a"
 distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{version}+dirty"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"
-
-[tool.versioningit.vcs]
-method = "git"
-match = ["v*"]
-default-tag = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,16 @@ default-version = "0.0.0+unknown"
 distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{version}+dirty"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"
+
+[tool.versioningit]
+default-version = "0.0.0+unknown"
+format = "{base_version}+{distance}.g{rev}"
+
+[tool.versioningit.tag2version]
+pattern = "v(?P<base_version>.*)"
+
+[tool.versioningit.versioning]
+scheme = "guess-next-dev"
+
+[tool.versioningit.commit]
+sha_length = 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,12 @@ classifiers = [
 #TODO: Add readthedocs link for `Documentation`
 Repository = "https://github.com/TT2024-B106/stmeasures.git"
 Issues = "https://github.com/TT2024-B106/stmeasures/issues"
+
+[tool.hatch.version]
+source = "versioningit"
+default-version = "0.0.0+unknown"
+
+[tool.hatch.version.format]
+distance = "{next_version}.dev{distance}+{vcs}{rev}"
+dirty = "{version}+dirty"
+distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
-requires = [
-    "hatchling",
-	"versioningit",
-]
+requires = ["hatchling", "versioningit"]
 build-backend = "hatchling.build"
 
 [project]
@@ -49,9 +46,11 @@ Issues = "https://github.com/TT2024-B106/stmeasures/issues"
 
 [tool.hatch.version]
 source = "versioningit"
+
+[tool.versioningit]
 default-version = "0.0.0a"
 
 [tool.versioningit.format]
-distance = "{base_version}dev{distance}{vcs}{rev}"
-dirty = "{base_version}d{build_date:%Y%m%d}"
-distance-dirty = "{base_version}dev{distance}{vcs}{rev}d{build_date:%Y%m%d}"
+distance = "{next_version}dev{distance}{vcs}{rev}"
+dirty = "{version}dirty"
+distance-dirty = "{next_version}dev{distance}{vcs}{rev}dirty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ default-version = "0.0.0a"
 format = "{base_version}+{distance}.g{rev}"
 
 [tool.versioningit.tag2version]
-pattern = "v(?P<base_version>.*)"
+pattern = "(?P<base_version>.*)"
 
 [tool.versioningit.versioning]
 scheme = "guess-next-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,6 @@ source = "versioningit"
 default-version = "0.0.0a"
 
 [tool.hatch.version.format]
-distance = "{next_version}dev{distance}{vcs}{rev}"
-dirty = "{version}dirty"
-distance-dirty = "{next_version}dev{distance}{vcs}{rev}dirty"
-
-[tool.hatch.build]
-artifacts = ["dist/_version.py"]
+distance = "{next_version}.dev{distance}+{vcs}{rev}"
+dirty = "{version}+dirty"
+distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ keywords = [
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "Intended Audience :: Science/Researchers",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",

--- a/stmeasures/example.py
+++ b/stmeasures/example.py
@@ -1,0 +1,2 @@
+def add_one(number):
+    return number + 1

--- a/stmeasures/example.py
+++ b/stmeasures/example.py
@@ -1,2 +1,5 @@
 def add_one(number):
     return number + 1
+
+def add_two(number):
+    return number + 2


### PR DESCRIPTION
# Continuous integration / Continuous Development

- Added Github Actions that build and deploy to beta.
- Deployment to beta is done in [TestPyPI](https://test.pypi.org/project/similarity-measures-b106/).
- Build is done through [Hatch](https://hatch.pypa.io/latest/).
- Used [versioningit](https://versioningit.readthedocs.io/en/stable/hatch.html) for versioning and named beta versions according to [PEP 440](https://peps.python.org/pep-0440/) standards, using only the integers of SHA commits.

## Further work

- [ ] Include `tests` in CI stage.
- [ ] Implement CI/CD for production.
- [ ] Pull last (production) tags to use them for `git tag`ging beta versions.